### PR TITLE
Explicitly allow periods in policy components.

### DIFF
--- a/src/proto/policy.proto
+++ b/src/proto/policy.proto
@@ -16,7 +16,7 @@ option java_package = "com.commonwealthrobotics.proto.policy";
 // colons) must follow this format:
 //
 // - The component may contain simple alphanumerics (a-z, A-Z, 0-9), hyphens (-), underscores
-// (_), and periods (.).
+// (_), periods (.) and forward slashes (/).
 // - The component may not contain colons (:).
 // - The component may contain zero or one wildcard characters (*). The component must end
 // immedately following the wildcard character. The part of the component before the wildcard

--- a/src/proto/policy.proto
+++ b/src/proto/policy.proto
@@ -15,8 +15,8 @@ option java_package = "com.commonwealthrobotics.proto.policy";
 // Action and resource specifiers are colon-separated strings. Each component of the string (between
 // colons) must follow this format:
 //
-// - The component may contain simple alphanumerics (a-z, A-Z, 0-9), hyphens (-), and underscores
-// (_).
+// - The component may contain simple alphanumerics (a-z, A-Z, 0-9), hyphens (-), underscores
+// (_), and periods (.).
 // - The component may not contain colons (:).
 // - The component may contain zero or one wildcard characters (*). The component must end
 // immedately following the wildcard character. The part of the component before the wildcard

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-projectVersion=0.7.0
+projectVersion=0.7.1


### PR DESCRIPTION
### Description of the Change

This PR extends the policy component docs to explicitly allow periods in components.

### Motivation

GitHub allows these in repository names (e.g. Julia repos end in `.jl` by convention).

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?
-->

### Applicable Issues

<!-- Enter any applicable Issues here. E.g., "Closes #49." -->
