### PR TITLE
Use a date for the PolicyDocument version instead of semver version number.

### DIFF
--- a/src/proto/policy.proto
+++ b/src/proto/policy.proto
@@ -35,13 +35,12 @@ option java_package = "com.commonwealthrobotics.proto.policy";
 // defined in multiple policies and one of the policies is a deny, that action-resource pair is
 // always denied.
 //
-// Next: 3
+// Next: 4
 message PolicyDocument {
   // A version number indicating the bowler-proto version this policy was written in. This may
   // determine how the policy is parsed. Check the bowler-proto releases for information on how
-  // versions may differ. This must be a valid semver version according to Semantic Versioning 2.0
-  // [here](https://semver.org/).
-  string version = 1;
+  // versions may differ. This must be a valid date of the form `yyyy-mm-dd`.
+  string version = 3;
 
   // The statements that this policy is comprised of.
   repeated PolicyContainer statements = 2;

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-projectVersion=0.7.1
+projectVersion=0.8.0


### PR DESCRIPTION
### Description of the Change

This PR switches from using a semver version number in PolicyDocument to using a date.

### Motivation

Explained in #24.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?
-->

### Applicable Issues

Closes #24.
